### PR TITLE
Fix dictionary configuration

### DIFF
--- a/tdxlib/tdx_integration.py
+++ b/tdxlib/tdx_integration.py
@@ -60,11 +60,13 @@ class TDXIntegration:
         self.logger = logging.getLogger('tdx_integration')
         self.config = configparser.ConfigParser()
         
-        if not filename:
+        if filename:
             self.load_config_from_file(filename)
 
-        if 'TDX API Settings' not in self.config:
+        if config:
             self.set_config(config)
+
+        if 'TDX API Settings' not in self.config:
             self.run_setup_wizard()
 
         self.config_to_attributes()
@@ -133,7 +135,7 @@ class TDXIntegration:
     def set_config(self, config: dict):
         if not config:
             config = self.default_config
-        
+
         self.config['TDX API Settings'] = config
 
     def run_setup_wizard(self):

--- a/tdxlib/tdx_integration.py
+++ b/tdxlib/tdx_integration.py
@@ -59,8 +59,9 @@ class TDXIntegration:
         self.cache = dict()
         self.logger = logging.getLogger('tdx_integration')
         self.config = configparser.ConfigParser()
-
-        self.load_config_from_file(filename)
+        
+        if not filename:
+            self.load_config_from_file(filename)
 
         if 'TDX API Settings' not in self.config:
             self.set_config(config)

--- a/test/test_setup.py
+++ b/test/test_setup.py
@@ -15,11 +15,10 @@ class TdxSetupTesting(unittest.TestCase):
 		interactively or from a file are not used when 
 		dictionary settings are provided.
 		"""
-		tdx = tdx_integration.TDXIntegration(config={
-			'TDX API Settings':{
-				"org_name":'example.edu'
-			}
-		})
+		tdx = tdx_integration.TDXIntegration(config=
+			{
+				"orgname":'example.edu'
+			})
 		assert mock_load.call_count == 0
 		assert mock_wizzard.call_count == 0
 

--- a/test/test_setup.py
+++ b/test/test_setup.py
@@ -1,0 +1,29 @@
+import unittest
+
+from unittest.mock import patch, Mock
+
+from tdxlib import tdx_integration
+
+# python -m unittest test.test_setup.TdxSetupTesting.test_init
+
+class TdxSetupTesting(unittest.TestCase):
+
+	@patch.object(tdx_integration.TDXIntegration, "load_config_from_file")
+	@patch.object(tdx_integration.TDXIntegration, "run_setup_wizard")
+	def test_init(self, mock_wizzard, mock_load):
+		"""Assert that functions for building configuration 
+		interactively or from a file are not used when 
+		dictionary settings are provided.
+		"""
+		tdx = tdx_integration.TDXIntegration(config={
+			'TDX API Settings':{
+				"org_name":'example.edu'
+			}
+		})
+		assert mock_load.call_count == 0
+		assert mock_wizzard.call_count == 0
+
+
+if __name__ == "__main__":
+    suite = unittest.TestLoader().loadTestsFromTestCase(TdxSetupTesting)
+    unittest.TextTestRunner(verbosity=2).run(suite)


### PR DESCRIPTION
- Do not try to open setting.ini file when a dictionary config is provided
- Do not run the interactive setup wizard when a dictionary config is provided
- Regression test for same